### PR TITLE
Clean up code and fix a few bugs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Conda = "1.3"
-Memento = "0.12"
+Memento = "1.0"
 PyCall = "1.91"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Conda = "1.3"
-Memento = "1.0"
+Memento = "1"
 PyCall = "1.91"
 julia = "1"
 

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -59,23 +59,23 @@ end
         debug_command::Bool=false,
     )
 
-A Server stores settings for create an pyftpdlib server.
+A Server stores settings to create a pyftpdlib server.
 
 # Arguments
-- `homedir::AbstractString=$HOMEDIR`: Directory where you want store to store your data for
-  the test server.
+- `homedir::AbstractString=$HOMEDIR`: Directory where you want to store your data for the
+  test server.
 
 # Keywords
 - `username::AbstractString=""`: Default login username. Defaults to 'userXXXX' where 'XXXX'
   is a number between 1 and 9999.
-- `password::AbstractString`: Default login password. Defalts to a random string of 40
+- `password::AbstractStringi=""`: Default login password. Defalts to a random string of 40
   characters.
 - `permission::AbstractString=$PERM`: Default user read/write permissions.
 - `security::Symbol=:none`: Security method to use for connecting (options: `:none`,
   `:implicit`, `:explicit`). Passing in `:none` will use FTP and passing in `:implicit` or
   `:explicit` will use the appropriate FTPS connection.
-- `force_gen_certs::Bool=true`: Force regenerate certificate and key file.
-- `debug_command::Bool=false`: Print out the python command being used for debugging
+- `force_gen_certs::Bool=true`: Force regeneration of certificate and key file.
+- `debug_command::Bool=false`: Print out the python command being used, for debugging
   purposes.
 """
 function Server(

--- a/src/server.py
+++ b/src/server.py
@@ -48,25 +48,8 @@ def create_self_signed_cert(cert_dir, cert_file, key_file, hostname):
             fp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode("utf-8"))
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("username", type=str)
-    parser.add_argument("password", type=str)
-    parser.add_argument("root", type=str)
-    parser.add_argument("--permissions", type=str, default="elr")
-    parser.add_argument("--hostname", type=str, default="localhost")
-    parser.add_argument("--port", type=int, default=0)
-    parser.add_argument("--passive-ports", type=str)
-    parser.add_argument("--tls", choices=["implicit", "explicit"])
-    parser.add_argument(
-        "--tls-require", choices=["control", "data"], nargs="*", default=[]
-    )
-    parser.add_argument("--cert-file", type=str, default="test.crt")
-    parser.add_argument("--key-file", type=str, default="test.key")
-    parser.add_argument("--debug", type=bool, default=False)
-    parser.add_argument("--gen-certs-dir", type=str, default="")
-
-    args = parser.parse_args()
+def main():
+    args = parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -77,6 +60,7 @@ if __name__ == "__main__":
         )
 
     if args.passive_ports:
+
         passive = tuple(int(p) for p in args.passive_ports.split("-"))
         if len(passive) > 2:
             raise ValueError("Passive port needs to be a range of two values")
@@ -87,7 +71,7 @@ if __name__ == "__main__":
             args.passive_ports = range(passive[0], passive[1] + 1)
 
     # Adapted from:
-    # http://pythonhosted.org/pyftpdlib/tutorial.html#building-a-base-ftp-server
+    # https://pyftpdlib.readthedocs.io/en/latest/tutorial.html#a-base-ftp-server
     authorizer = DummyAuthorizer()
     authorizer.add_user(
         args.username, args.password, args.root, perm=args.permissions,
@@ -111,3 +95,30 @@ if __name__ == "__main__":
 
     server = FTPServer((args.hostname, args.port), handler)
     server.serve_forever()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("username", type=str)
+    parser.add_argument("password", type=str)
+    parser.add_argument("root", type=str)
+    parser.add_argument("--permissions", type=str, default="elr")
+    parser.add_argument("--hostname", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument(
+        "--passive-ports", type=str, help="port or port range. ex: 1337, 1337-1447"
+    )
+    parser.add_argument("--tls", choices=["implicit", "explicit"])
+    parser.add_argument(
+        "--tls-require", choices=["control", "data"], nargs="*", default=[]
+    )
+    parser.add_argument("--cert-file", type=str, default="test.crt")
+    parser.add_argument("--key-file", type=str, default="test.key")
+    parser.add_argument("--debug", type=bool, default=False)
+    parser.add_argument("--gen-certs-dir", type=str, default="")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server.py
+++ b/src/server.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from os.path import exists, join, realpath
+from pathlib import Path
 
 from OpenSSL import crypto
 from pyftpdlib.authorizers import DummyAuthorizer
@@ -22,59 +22,49 @@ class TLSImplicit_FTPHandler(TLS_FTPHandler):
         self.respond("550 not supposed to be used with implicit SSL.")
 
 
-def create_self_signed_cert(cert_dir, cert_file, key_file, hostname):
+def create_self_signed_cert(cert_file, key_file, hostname):
     # from https://gist.github.com/ril3y/1165038
-    cert_path = realpath(join(cert_dir, cert_file))
-    key_path = realpath(join(cert_dir, key_file))
 
-    if not exists(cert_path) or not exists(key_path):
-        # create a key pair
-        k = crypto.PKey()
-        k.generate_key(crypto.TYPE_RSA, 1024)
+    # create a key pair
+    k = crypto.PKey()
+    k.generate_key(crypto.TYPE_RSA, 1024)
 
-        # create a self-signed cert
-        cert = crypto.X509()
-        cert.get_subject().CN = hostname
-        cert.set_serial_number(1000)
-        cert.gmtime_adj_notBefore(0)
-        cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
-        cert.set_issuer(cert.get_subject())
-        cert.set_pubkey(k)
-        cert.sign(k, "sha256")
+    # create a self-signed cert
+    cert = crypto.X509()
+    cert.get_subject().CN = hostname
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(k)
+    cert.sign(k, "sha256")
 
-        with open(cert_path, "wt") as fp:
-            fp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"))
-        with open(key_path, "wt") as fp:
-            fp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode("utf-8"))
+    with cert_file.open("wt") as fp:
+        fp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"))
+    with key_file.open("wt") as fp:
+        fp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode("utf-8"))
 
 
 def main():
     args = parse_args()
+    cert_file = args.cert_file
+    key_file = args.key_file
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
-    if args.gen_certs_dir:
-        create_self_signed_cert(
-            args.gen_certs_dir, args.cert_file, args.key_file, args.hostname
-        )
-
-    if args.passive_ports:
-        passive = tuple(int(p) for p in args.passive_ports.split("-"))
-        if len(passive) > 2:
-            raise ValueError("Passive port needs to be a range of two values")
-
-        if len(passive) == 1:
-            args.passive_ports = range(passive[0], passive[0] + 1)
-        else:
-            args.passive_ports = range(passive[0], passive[1] + 1)
+    # If either the cert or key doesn't exist, then we need to regenerate both of them
+    # If force_gen is True, then we regenerate both the cert and key regardless
+    # We only need to do this if we're using TLS
+    if args.tls and (
+        not cert_file.exists() or not key_file.exists() or args.force_gen_certs
+    ):
+        create_self_signed_cert(cert_file, key_file, args.hostname)
 
     # Adapted from:
     # https://pyftpdlib.readthedocs.io/en/latest/tutorial.html#a-base-ftp-server
     authorizer = DummyAuthorizer()
-    authorizer.add_user(
-        args.username, args.password, args.root, perm=args.permissions,
-    )
+    authorizer.add_user(args.username, args.password, args.root, perm=args.permissions)
 
     if args.tls == "implicit":
         handler = TLSImplicit_FTPHandler
@@ -84,11 +74,20 @@ def main():
         handler = FTPHandler
 
     handler.authorizer = authorizer
-    handler.passive_ports = args.passive_ports
+
+    if args.passive_ports:
+        passive = tuple(int(p) for p in args.passive_ports.split("-"))
+        if len(passive) > 2:
+            raise ValueError("Passive port needs to be a range of two values")
+
+        if len(passive) == 1:
+            handler.passive_ports = range(passive[0], passive[0] + 1)
+        else:
+            handler.passive_ports = range(passive[0], passive[1] + 1)
 
     if args.tls:
-        handler.certfile = args.cert_file
-        handler.keyfile = args.key_file
+        handler.certfile = str(cert_file)
+        handler.keyfile = str(key_file)
         handler.tls_control_required = "control" in args.tls_require
         handler.tls_data_required = "data" in args.tls_require
 
@@ -98,23 +97,53 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("username", type=str)
-    parser.add_argument("password", type=str)
-    parser.add_argument("root", type=str)
-    parser.add_argument("--permissions", type=str, default="elr")
-    parser.add_argument("--hostname", type=str, default="localhost")
-    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("username", type=str, help="FTP Server Username")
+    parser.add_argument("password", type=str, help="FTP Server Password")
+    parser.add_argument("root", type=str, help="FTP Server root directory")
+    parser.add_argument(
+        "--permissions", type=str, default="elr", help="FTP Server permissions"
+    )
+    parser.add_argument(
+        "--hostname", type=str, default="localhost", help="hostname to use"
+    )
+    parser.add_argument(
+        "--port", type=int, default=0, help="By default the port will be randomized"
+    )
     parser.add_argument(
         "--passive-ports", type=str, help="port or port range. ex: 1337, 1337-1447"
     )
-    parser.add_argument("--tls", choices=["implicit", "explicit"])
     parser.add_argument(
-        "--tls-require", choices=["control", "data"], nargs="*", default=[]
+        "--tls",
+        type=str,
+        choices=["implicit", "explicit"],
+        help="use TLS in implicit or explicit mode",
     )
-    parser.add_argument("--cert-file", type=str, default="test.crt")
-    parser.add_argument("--key-file", type=str, default="test.key")
-    parser.add_argument("--debug", action="store_true")
-    parser.add_argument("--gen-certs-dir", type=str, default="")
+    parser.add_argument(
+        "--tls-require",
+        type=list,
+        choices=["control", "data"],
+        nargs="*",
+        default=[],
+        help="Determine if TLS should be established on the data or control channel",
+    )
+    parser.add_argument(
+        "--cert-file",
+        type=lambda p: Path(p).absolute(),
+        default=Path("test.crt"),
+        help="Path to the certificate file",
+    )
+    parser.add_argument(
+        "--key-file",
+        type=lambda p: Path(p).absolute(),
+        default=Path("test.key"),
+        help="Path to the key file",
+    )
+    parser.add_argument(
+        "--force-gen-certs",
+        action="store_true",
+        help="Regenerate certificate and key files regardless if they exist or not",
+    )
+    parser.add_argument("--debug", action="store_true", help="Display DEBUG messages")
 
     return parser.parse_args()
 

--- a/src/server.py
+++ b/src/server.py
@@ -26,8 +26,8 @@ def create_self_signed_cert(cert_dir, cert_file, key_file, hostname):
     # from https://gist.github.com/ril3y/1165038
     cert_path = realpath(join(cert_dir, cert_file))
     key_path = realpath(join(cert_dir, key_file))
-    if not exists(cert_path) or not exists(key_path):
 
+    if not exists(cert_path) or not exists(key_path):
         # create a key pair
         k = crypto.PKey()
         k.generate_key(crypto.TYPE_RSA, 1024)
@@ -60,7 +60,6 @@ def main():
         )
 
     if args.passive_ports:
-
         passive = tuple(int(p) for p in args.passive_ports.split("-"))
         if len(passive) > 2:
             raise ValueError("Passive port needs to be a range of two values")
@@ -114,7 +113,7 @@ def parse_args():
     )
     parser.add_argument("--cert-file", type=str, default="test.crt")
     parser.add_argument("--key-file", type=str, default="test.key")
-    parser.add_argument("--debug", type=bool, default=False)
+    parser.add_argument("--debug", action="store_true")
     parser.add_argument("--gen-certs-dir", type=str, default="")
 
     return parser.parse_args()

--- a/src/server.py
+++ b/src/server.py
@@ -40,7 +40,7 @@ def create_self_signed_cert(cert_dir, cert_file, key_file, hostname):
         cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
         cert.set_issuer(cert.get_subject())
         cert.set_pubkey(k)
-        cert.sign(k, "sha1")
+        cert.sign(k, "sha256")
 
         with open(cert_path, "wt") as fp:
             fp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"))

--- a/src/server.py
+++ b/src/server.py
@@ -1,8 +1,8 @@
-from OpenSSL import crypto
+import argparse
+import logging
 from os.path import exists, join, realpath
 
-import logging
-import argparse
+from OpenSSL import crypto
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler, TLS_FTPHandler
 from pyftpdlib.servers import FTPServer
@@ -37,33 +37,34 @@ def create_self_signed_cert(cert_dir, cert_file, key_file, hostname):
         cert.get_subject().CN = hostname
         cert.set_serial_number(1000)
         cert.gmtime_adj_notBefore(0)
-        cert.gmtime_adj_notAfter(10*365*24*60*60)
+        cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
         cert.set_issuer(cert.get_subject())
         cert.set_pubkey(k)
-        cert.sign(k, 'sha1')
+        cert.sign(k, "sha1")
 
         with open(cert_path, "wt") as fp:
-            fp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8'))
+            fp.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"))
         with open(key_path, "wt") as fp:
-            fp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode('utf-8'))
+            fp.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode("utf-8"))
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('username', type=str)
-    parser.add_argument('password', type=str)
-    parser.add_argument('root', type=str)
-    parser.add_argument('--permissions', type=str, default="elr")
-    parser.add_argument('--hostname', type=str, default="localhost")
-    parser.add_argument('--port', type=int, default=0)
-    parser.add_argument('--passive-ports', type=str)
-    parser.add_argument('--tls', choices=['implicit', 'explicit'])
-    parser.add_argument('--tls-require', choices=['control', 'data'], nargs='*', default=[])  # noqa
-    parser.add_argument('--cert-file', type=str, default='test.crt')
-    parser.add_argument('--key-file', type=str, default='test.key')
-    parser.add_argument('--debug', type=bool, default=False)
-    parser.add_argument('--gen-certs-dir', type=str, default='')
+    parser.add_argument("username", type=str)
+    parser.add_argument("password", type=str)
+    parser.add_argument("root", type=str)
+    parser.add_argument("--permissions", type=str, default="elr")
+    parser.add_argument("--hostname", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--passive-ports", type=str)
+    parser.add_argument("--tls", choices=["implicit", "explicit"])
+    parser.add_argument(
+        "--tls-require", choices=["control", "data"], nargs="*", default=[]
+    )
+    parser.add_argument("--cert-file", type=str, default="test.crt")
+    parser.add_argument("--key-file", type=str, default="test.key")
+    parser.add_argument("--debug", type=bool, default=False)
+    parser.add_argument("--gen-certs-dir", type=str, default="")
 
     args = parser.parse_args()
 
@@ -71,10 +72,12 @@ if __name__ == '__main__':
         logging.basicConfig(level=logging.DEBUG)
 
     if args.gen_certs_dir:
-        create_self_signed_cert(args.gen_certs_dir, args.cert_file, args.key_file, args.hostname)
+        create_self_signed_cert(
+            args.gen_certs_dir, args.cert_file, args.key_file, args.hostname
+        )
 
     if args.passive_ports:
-        passive = tuple(int(p) for p in args.passive_ports.split('-'))
+        passive = tuple(int(p) for p in args.passive_ports.split("-"))
         if len(passive) > 2:
             raise ValueError("Passive port needs to be a range of two values")
 
@@ -83,18 +86,16 @@ if __name__ == '__main__':
         else:
             args.passive_ports = range(passive[0], passive[1] + 1)
 
-    # Adapted from: http://pythonhosted.org/pyftpdlib/tutorial.html#building-a-base-ftp-server  # noqa
+    # Adapted from:
+    # http://pythonhosted.org/pyftpdlib/tutorial.html#building-a-base-ftp-server
     authorizer = DummyAuthorizer()
     authorizer.add_user(
-        args.username,
-        args.password,
-        args.root,
-        perm=args.permissions,
+        args.username, args.password, args.root, perm=args.permissions,
     )
 
-    if args.tls == 'implicit':
+    if args.tls == "implicit":
         handler = TLSImplicit_FTPHandler
-    elif args.tls == 'explicit':
+    elif args.tls == "explicit":
         handler = TLS_FTPHandler
     else:
         handler = FTPHandler
@@ -105,8 +106,8 @@ if __name__ == '__main__':
     if args.tls:
         handler.certfile = args.cert_file
         handler.keyfile = args.key_file
-        handler.tls_control_required = 'control' in args.tls_require
-        handler.tls_data_required = 'data' in args.tls_require
+        handler.tls_control_required = "control" in args.tls_require
+        handler.tls_data_required = "data" in args.tls_require
 
     server = FTPServer((args.hostname, args.port), handler)
     server.serve_forever()

--- a/src/server.py
+++ b/src/server.py
@@ -129,13 +129,13 @@ def parse_args():
     parser.add_argument(
         "--cert-file",
         type=lambda p: Path(p).absolute(),
-        default=Path("test.crt"),
+        default="test.crt",
         help="Path to the certificate file",
     )
     parser.add_argument(
         "--key-file",
         type=lambda p: Path(p).absolute(),
-        default=Path("test.key"),
+        default="test.key",
         help="Path to the key file",
     )
     parser.add_argument(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using FTPServer
 using FTPClient
+using Memento
+using Memento.TestUtils: @test_log
 using Test
 
 @testset "FTPServer.jl" begin
@@ -19,8 +21,16 @@ using Test
             @test resp.code == 226
         end
     end
-    @testset "ssl - $mode" for mode in (:explicit, :implicit)
-        FTPServer.serve(; security=mode) do server
+    @testset "no-ssl debug true" begin
+        @test_log(
+            FTPServer.LOGGER,
+            "info",
+            r"^Running Command:.*",
+            FTPServer.Server(; debug_command=true),
+        )
+    end
+    @testset "ssl - $mode - $gen_cert" for mode in (:explicit, :implicit), gen_cert in (true, false)
+        FTPServer.serve(; security=mode, force_gen_certs=gen_cert) do server
             opts = (
                 :hostname => FTPServer.hostname(server),
                 :port => FTPServer.port(server),


### PR DESCRIPTION
Closes #6 

Aside from closing that small docs issue, it was noticed that the julia code calling the python script was incorrect. It was setting a flag that didn't exist, and a bug was fixed where the first line returned by the command wasn't the ip/port. 

The python code `server.py` was cleaned up, and a few small changes were made. For one, the cert is now signed with SHA256 instead of SHA1, and the main function has been split up into a few functions.

Initially I was looking into this due to an SSL error we saw, but it turns out that is an actual OpenSSL issue with version `1.1.1e`. 