### PR TITLE
Pin openssl to 1.1.1d. Bump version to 0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ Manifest.toml
 *.jl.*.cov
 *.jl.mem
 /deps/usr
+/deps/build.log
 /Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FTPServer"
 uuid = "9c2b0ca7-0fb3-5789-8f1a-7604e426024c"
 author = "Invenia Technical Computing Corperation"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,7 @@
+using Conda
+
+# OpenSSL 1.1.1e added in a breaking change that is affecting many FTP clients.
+# For now, we can pin to 1.1.1d until it is fixed.
+# https://github.com/openssl/openssl/issues/11381
+# https://github.com/openssl/openssl/issues/11378
+Conda.add("openssl==1.1.1d")

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -29,7 +29,7 @@ const PYTHON_CMD = joinpath(
 
 function __init__()
     Memento.register(LOGGER)
-
+    Conda.add("openssl==1.1.1d")
     copy!(pyopenssl_crypto, pyimport_conda("OpenSSL.crypto", "OpenSSL"))
     copy!(pyopenssl_SSL, pyimport_conda("OpenSSL.SSL", "OpenSSL"))
     copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib", "invenia"))

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -29,13 +29,6 @@ const PYTHON_CMD = joinpath(
 
 function __init__()
     Memento.register(LOGGER)
-
-    # OpenSSL 1.1.1e added in a breaking change that is affecting many FTP clients.
-    # For now, we can pin to 1.1.1d until it is fixed.
-    # https://github.com/openssl/openssl/issues/11381
-    # https://github.com/openssl/openssl/issues/11378
-    Conda.add("openssl==1.1.1d")
-
     copy!(pyopenssl_crypto, pyimport_conda("OpenSSL.crypto", "OpenSSL"))
     copy!(pyopenssl_SSL, pyimport_conda("OpenSSL.SSL", "OpenSSL"))
     copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib", "invenia"))

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -29,7 +29,13 @@ const PYTHON_CMD = joinpath(
 
 function __init__()
     Memento.register(LOGGER)
+
+    # OpenSSL 1.1.1e added in a breaking change that is affecting many FTP clients.
+    # For now, we can pin to 1.1.1d until it is fixed.
+    # https://github.com/openssl/openssl/issues/11381
+    # https://github.com/openssl/openssl/issues/11378
     Conda.add("openssl==1.1.1d")
+
     copy!(pyopenssl_crypto, pyimport_conda("OpenSSL.crypto", "OpenSSL"))
     copy!(pyopenssl_SSL, pyimport_conda("OpenSSL.SSL", "OpenSSL"))
     copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib", "invenia"))


### PR DESCRIPTION
Relevant openssl issues:
https://github.com/openssl/openssl/issues/11381
https://github.com/openssl/openssl/issues/11378

Pin openssl to 1.1.1d so we don't hit the openssl issues.