### PR TITLE
Add test for OpenSSL 1.1.1e bug

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,0 @@
-using Conda
-
-# OpenSSL 1.1.1e added in a breaking change that is affecting many FTP clients.
-# For now, we can pin to 1.1.1d until it is fixed.
-# https://github.com/openssl/openssl/issues/11381
-# https://github.com/openssl/openssl/issues/11378
-Conda.add("openssl==1.1.1d")

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -200,4 +200,27 @@ function cleanup()
     isfile(FTPServer.KEY) && rm(FTPServer.KEY)
 end
 
+"""
+    uri(server::Server)
+
+Create an FTP URI from an FTP server object.
+
+# Arguments
+- `server::Server`: FTPServer object
+"""
+function uri(server::Server)
+    ftp_type = if server.security == :implicit
+        "ftps"
+    server.security == :explicit
+        "ftpes"
+    else
+        "ftp"
+    end
+
+    string(
+        "$ftp_type://$(username(server)):$(password(server))",
+        "@$(hostname(server)):$(port(server))",
+    )
+end
+
 end # module

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -209,9 +209,9 @@ Create an FTP URI from an FTP server object.
 - `server::Server`: FTPServer object
 """
 function uri(server::Server)
-    ftp_type = if server.security == :implicit
+    ftp_type = if server.security === :implicit
         "ftps"
-    server.security == :explicit
+    server.security === :explicit
         "ftpes"
     else
         "ftp"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,18 @@
-using FTPServer
 using FTPClient
+using FTPServer
+using FTPServer: Server, serve, username, password, hostname, port, HOMEDIR
 using Memento
 using Memento.TestUtils: @test_log
 using Test
+
+
+function uri(server::Server; ftp_type::String="ftp")
+    string(
+        "$ftp_type://$(username(server)):$(password(server))",
+        "@$(hostname(server)):$(port(server))",
+    )
+end
+
 
 @testset "FTPServer.jl" begin
     FTPServer.init()
@@ -49,9 +59,20 @@ using Test
         end
     end
 
+    @testset "openssl 1.1.1e" begin
+        FTPServer.serve(".", security=:implicit) do server
+            ftp = FTP(uri(server; ftp_type="ftps"), verify_peer=false)
+            # With OpenSSL 1.1.1e this will fail due to a new EOF change that was added.
+            # https://github.com/openssl/openssl/issues/11381
+            # https://github.com/openssl/openssl/issues/11378
+            @test_broken upload(ftp, "$HOMEDIR/test_download.txt", "/FOO")
+        end
+    end
+
     FTPServer.cleanup()
 
     @test !isfile(FTPServer.CERT)
     @test !isfile(FTPServer.KEY)
     @test !isdir(FTPServer.HOMEDIR)
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using FTPClient
 using FTPServer
-using FTPServer: Server, serve, username, password, hostname, port, HOMEDIR, uri
+using FTPServer: HOMEDIR, uri
 using Memento
 using Memento.TestUtils: @test_log
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,9 @@
 using FTPClient
 using FTPServer
-using FTPServer: Server, serve, username, password, hostname, port, HOMEDIR
+using FTPServer: Server, serve, username, password, hostname, port, HOMEDIR, uri
 using Memento
 using Memento.TestUtils: @test_log
 using Test
-
-
-function uri(server::Server; ftp_type::String="ftp")
-    string(
-        "$ftp_type://$(username(server)):$(password(server))",
-        "@$(hostname(server)):$(port(server))",
-    )
-end
 
 
 @testset "FTPServer.jl" begin
@@ -61,7 +53,7 @@ end
 
     @testset "openssl 1.1.1e" begin
         FTPServer.serve(".", security=:implicit) do server
-            ftp = FTP(uri(server; ftp_type="ftps"), verify_peer=false)
+            ftp = FTP(uri(server), verify_peer=false)
             # With OpenSSL 1.1.1e this will fail due to a new EOF change that was added.
             # https://github.com/openssl/openssl/issues/11381
             # https://github.com/openssl/openssl/issues/11378


### PR DESCRIPTION
As mentioned in #15 OpenSSL Introduced a change to their EOF parsing that caused timeout issues on many FTP Clients. 

https://github.com/openssl/openssl/issues/11381
https://github.com/openssl/openssl/issues/11378 

Lets add a broken test here, so that we are informed when the issue is fixed. 