### PR TITLE
Set pyftpdlib version to exactly 1.5.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FTPServer"
 uuid = "9c2b0ca7-0fb3-5789-8f1a-7604e426024c"
 author = "Invenia Technical Computing Corperation"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -29,9 +29,15 @@ const PYTHON_CMD = joinpath(
 
 function __init__()
     Memento.register(LOGGER)
+
     copy!(pyopenssl_crypto, pyimport_conda("OpenSSL.crypto", "OpenSSL"))
     copy!(pyopenssl_SSL, pyimport_conda("OpenSSL.SSL", "OpenSSL"))
-    copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib", "invenia"))
+
+    # Note: For `pyftpdlib` we'll specify an exact version to make behaviour of FTPServer.jl
+    # consistent when rolling back to an earlier version.
+    # For details see: https://github.com/invenia/FTPClient.jl/issues/91#issuecomment-632698841
+    copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib==1.5.4", "invenia"))
+
     mkpath(ROOT)
 end
 


### PR DESCRIPTION
Using a specific version of `pyftpdlib` should allow for consistent FTP server behaviour when using a specific version of FTPServer.jl.

For details see: https://github.com/invenia/FTPClient.jl/issues/91#issuecomment-632698841