### PR TITLE
Update to pyftpdlib 1.5.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FTPServer"
 uuid = "9c2b0ca7-0fb3-5789-8f1a-7604e426024c"
 author = "Invenia Technical Computing Corperation"
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -36,7 +36,7 @@ function __init__()
     # Note: For `pyftpdlib` we'll specify an exact version to make behaviour of FTPServer.jl
     # consistent when rolling back to an earlier version.
     # For details see: https://github.com/invenia/FTPClient.jl/issues/91#issuecomment-632698841
-    copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib==1.5.4", "invenia"))
+    copy!(pyftpdlib_servers, pyimport_conda("pyftpdlib.servers", "pyftpdlib==1.5.6", "invenia"))
 
     mkpath(ROOT)
 end


### PR DESCRIPTION
Updates to the latest version of pyftpdlib. As reported in https://github.com/invenia/FTPClient.jl/issues/91 this change is breaking for FTPClient.jl's tests which is why I made this a breaking release.

It is debatable whether this should be just a patch or not but in this case it seems like the simplest path forward is to make this breaking. If we did make this a patch release then FTPClient would need to a patch release where `< 0.2.4` was specified.