### PR TITLE
Use the same version of Python used by PyCall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,45 @@ os:
   - windows
 julia:
   - 1.0  # LTS
-  - 1.3  # Latest release
+  - 1    # Latest release
   - nightly
 arch:
   - x64
   - x86
 env:
-  global:
-    - PYTHON=""
-    - CONDA_JL_VERSION="3"  # Documentation stage will use the first variable set
+  # Note: Explicitly included jobs (the "Documentation stage) will use this set of variables
+  - PYTHON="" CONDA_JL_VERSION="3"
+
+  # Note: This variable is just a place holder and is only needed to have Travis respect
+  # our exclude rules (having and exclude with `env: ""` does not work)
+  - SYS_PYTHON=""
 jobs:
   allow_failures:
     - julia: nightly
 
   fast_finish: true
 
-  # Test 32-bit only on Linux
   exclude:
+    # Only test 32-bit on Linux
     - arch: x86
       os: osx
     - arch: x86
       os: windows
 
+    # Only test system Python on current Julia release
+    - julia: 1.0
+      env: SYS_PYTHON=""
+    - julia: nightly
+      env: SYS_PYTHON=""
+    - os: windows
+      env: SYS_PYTHON=""
+
   include:
+    # Note: Conda.jl cannot be used on ARM currently which means we have to use a system Python install
+    - julia: 1
+      arch: arm64
+      env: SYS_PYTHON=""
+
     - stage: "Documentation"
       julia: 1
       os: linux
@@ -44,6 +60,15 @@ notifications:
     on_success: never
     on_failure: always
     if: type = cron
+
+before_install:
+  - |
+    if [ -z ${PYTHON+x} ]; then
+        sudo apt-get -q update
+        sudo apt-get -y install python3 python3-pip
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install pyopenssl pyftpdlib
+    fi
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Julia interface for running a test FTP server with [pyftpdlib](https://pyftpdl
 ## Prerequisites
 
 FTPServer makes use of PyCall for running the FTP server.
-It's recommended that you use [`PYTHON=""`](https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version) so that Julia uses it's own Python distribution.
+It's recommended that you use [`PYTHON=""`](https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version) so that Julia uses its own Python distribution.
 However, if you wish to specify a system Python you'll to at least use Python 3 and install the Python packages `pyopenssl` and `pyftpdlib`.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Julia interface for running a test FTP server with [pyftpdlib](https://pyftpdl
 
 FTPServer makes use of PyCall for running the FTP server.
 It's recommended that you use [`PYTHON=""`](https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version) so that Julia uses its own Python distribution.
-However, if you wish to specify a system Python you'll to at least use Python 3 and install the Python packages `pyopenssl` and `pyftpdlib`.
+However, if you wish to specify a system Python you will need to use at least Python 3 and install the Python packages `pyopenssl` and `pyftpdlib`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 A Julia interface for running a test FTP server with [pyftpdlib](https://pyftpdlib.readthedocs.io/en/latest/index.html).
 
+## Prerequisites
+
+FTPServer makes use of PyCall for running the FTP server.
+It's recommended that you use [`PYTHON=""`](https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version) so that Julia uses it's own Python distribution.
+However, if you wish to specify a system Python you'll to at least use Python 3 and install the Python packages `pyopenssl` and `pyftpdlib`.
+
 ## Usage
 
 Since this package is primarily intended for test ftp logic, we recommend using the `FTPServer.serve`

--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -23,9 +23,6 @@ const ROOT = abspath(joinpath(dirname(dirname(@__FILE__)), "deps", "usr", "ftp")
 const HOMEDIR = joinpath(ROOT, "data")
 const CERT = joinpath(ROOT, "test.crt")
 const KEY = joinpath(ROOT, "test.key")
-const PYTHON_CMD = joinpath(
-    Conda.PYTHONDIR, Sys.iswindows() ? "python.exe" : "python"
-)
 
 function __init__()
     Memento.register(LOGGER)
@@ -99,7 +96,8 @@ function Server(
         password = randstring(40)
     end
 
-    cmd = `$PYTHON_CMD $SCRIPT $username $password $homedir --permissions $permissions`
+    python = PyCall.current_python()
+    cmd = `$python $SCRIPT $username $password $homedir --permissions $permissions`
     if security != :none
         cmd = `$cmd --tls $security --cert-file $CERT --key-file $KEY`
 


### PR DESCRIPTION
Supporting the version of Python used by PyCall means supporting system Python installations. Having this support is required for ARM as Conda is not supported on the ARM platform.