### PR TITLE
Re-enable test previously marked as broken

### DIFF
--- a/src/FTPServer.jl
+++ b/src/FTPServer.jl
@@ -116,7 +116,7 @@ function Server(
     # Note: open(::AbstractCmd, ...) won't work here as it doesn't allow us to capture
     # STDERR.
     io = Pipe()
-    process = run(pipeline(cmd, stdout=io, stderr=io), wait=false)
+    process = run(cmd)
 
     # Grab the Port value from the python script output
     line = readline(io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,13 +51,11 @@ using Test
         end
     end
 
-    @testset "openssl 1.1.1e" begin
+    @testset "openssl 1.1.1 (f, n, or m)" begin
         FTPServer.serve(".", security=:implicit) do server
             ftp = FTP(uri(server), verify_peer=false)
-            # With OpenSSL 1.1.1e this will fail due to a new EOF change that was added.
-            # https://github.com/openssl/openssl/issues/11381
-            # https://github.com/openssl/openssl/issues/11378
-            @test_broken upload(ftp, "$HOMEDIR/test_download.txt", "/FOO")
+            # TODO: This is currently failing with a `LibCURL error #28`
+            @test upload(ftp, "$HOMEDIR/test_download.txt", "/FOO")
         end
     end
 


### PR DESCRIPTION
An issue unrelated to the reason the test was marked broken came up with uploading to the FTP server. Removing the broken status of this test to better track the status of the issue.

Related: https://github.com/invenia/FTPServer.jl/issues/36